### PR TITLE
Typo arguments => args

### DIFF
--- a/src/EbayServices.php
+++ b/src/EbayServices.php
@@ -15,7 +15,7 @@ class EbayServices
         $this->sdk = new Sdk($config);
     }
 
-    function __call($name, $arguments)
+    function __call($name, $args)
     {
         if (strpos($name, 'create') === 0) {
             $service = 'create'.substr($name, 6);


### PR DESCRIPTION
Because of the typo you can't create services which require additional parameters like the Inventory service.